### PR TITLE
[AVANT-3836] Upgrade jspdf to ^3.0.1 and jspdf-autotable to ^5.0.2 for security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
-    "jspdf-autotable": "3.5.9",
+    "jspdf": "^3.0.1",
+    "jspdf-autotable": "^5.0.2",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.1.0",
     "react-double-scrollbar": "0.0.15"


### PR DESCRIPTION
Updated jspdf-autotable to ^5.0.2 and jspdf version ^3.0.1 for security vulnerability fix.