### PR TITLE
AVANT-4474: Fix for material table jspdf critical CVE-2025-68428

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "^3.0.1",
-    "jspdf-autotable": "^5.0.2",
+    "jspdf": "^4.0.0",
+    "jspdf-autotable": "^5.0.7",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.1.0",
     "react-double-scrollbar": "0.0.15"


### PR DESCRIPTION
Fix for Material Table - JSPDF Critical CVE-2025-68428